### PR TITLE
prover: use Keccak256 implementation form Gnark

### DIFF
--- a/prover/deletion_circuit.go
+++ b/prover/deletion_circuit.go
@@ -2,12 +2,13 @@ package prover
 
 import (
 	"fmt"
-	"worldcoin/gnark-mbu/prover/keccak"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/reilabs/gnark-lean-extractor/v2/abstractor"
+
+	"worldcoin/gnark-mbu/prover/keccak"
 )
 
 type DeletionMbuCircuit struct {
@@ -48,7 +49,10 @@ func (circuit *DeletionMbuCircuit) Define(api frontend.API) error {
 	bits_post := abstractor.Call1(api, ToReducedBigEndian{Variable: circuit.PostRoot, Size: 256})
 	bits = append(bits, bits_post...)
 
-	hash := keccak.NewKeccak256(api, circuit.BatchSize*32+2*256, bits...)
+	hash, err := keccak.Keccak256(api, circuit.BatchSize*32+2*256, bits...)
+	if err != nil {
+		return err
+	}
 	sum := abstractor.Call(api, FromBinaryBigEndian{Variable: hash})
 
 	// The same endianness conversion has been performed in the hash generation

--- a/prover/insertion_circuit.go
+++ b/prover/insertion_circuit.go
@@ -50,7 +50,10 @@ func (circuit *InsertionMbuCircuit) Define(api frontend.API) error {
 		bits = append(bits, bits_id...)
 	}
 
-	hash := keccak.NewKeccak256(api, (circuit.BatchSize+2)*256+32, bits...)
+	hash, err := keccak.Keccak256(api, (circuit.BatchSize+2)*256+32, bits...)
+	if err != nil {
+		return err
+	}
 	sum := abstractor.Call(api, FromBinaryBigEndian{Variable: hash})
 
 	// The same endianness conversion has been performed in the hash generation

--- a/prover/keccak/keccak_test.go
+++ b/prover/keccak/keccak_test.go
@@ -16,7 +16,10 @@ type TestKeccakCircuit1 struct {
 }
 
 func (circuit *TestKeccakCircuit1) Define(api frontend.API) error {
-	hash := NewKeccak256(api, len(circuit.Input), circuit.Input[:]...)
+	hash, err := Keccak256(api, len(circuit.Input), circuit.Input[:]...)
+	if err != nil {
+		return err
+	}
 	sum := api.FromBinary(hash...)
 	api.AssertIsEqual(circuit.Hash, sum)
 	return nil
@@ -28,7 +31,10 @@ type TestKeccakCircuit2 struct {
 }
 
 func (circuit *TestKeccakCircuit2) Define(api frontend.API) error {
-	hash := NewKeccak256(api, 0)
+	hash, err := Keccak256(api, 0)
+	if err != nil {
+		return err
+	}
 	sum := api.FromBinary(hash...)
 	api.AssertIsEqual(circuit.Hash, sum)
 	return nil
@@ -40,7 +46,10 @@ type TestKeccakCircuitBlockSize struct {
 }
 
 func (circuit *TestKeccakCircuitBlockSize) Define(api frontend.API) error {
-	hash := NewKeccak256(api, len(circuit.Input), circuit.Input[:]...)
+	hash, err := Keccak256(api, len(circuit.Input), circuit.Input[:]...)
+	if err != nil {
+		return err
+	}
 	sum := api.FromBinary(hash...)
 	api.AssertIsEqual(circuit.Hash, sum)
 	return nil


### PR DESCRIPTION
In keccak package add a wrapper converting []frontend.Variable to []uints.U8 expected by NewLegacykeccak256. Use the wrapper in insertion and deletion circuits instead of our Keccak256 implementation. Use this wrapper in existing Keccak tests to make sure the behavior of the wrapper with the new implementation is the same as with the old implementation.