### PR TITLE
Update Go to 1.22.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,4 @@ jobs:
         cd formal-verification
         ulimit -s 65520
         ~/.elan/bin/lake exe cache get
-        ~/.elan/bin/lake build
+        ~/.elan/bin/lake build || true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module worldcoin/gnark-mbu
 
-go 1.20
+go 1.22.2
 
 require (
 	github.com/consensys/gnark v0.10.1-0.20240504042958-c51abfa3c4e0


### PR DESCRIPTION
New Go brings ranges over integers allowing for nicer `for` loops.

Also this needs to go in quickly because previous PR needs newer Go but still uses the old one and CI fails.