### PR TITLE
insertion_circuit: use versioned KZG hash

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -103,10 +103,11 @@ func TestInsertionHappyPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	versionedKzgHash := prover.KzgToVersionedHash(ir.Commitment4844)
 	publicWitness, err := frontend.NewWitness(&prover.InsertionMbuCircuit{
 		InputHash:          ir.InputHash,
-		ExpectedEvaluation: ir.ExpectedEvaluation[:],
-		Commitment4844:     ir.Commitment4844[:],
+		ExpectedEvaluation: *prover.BytesToBn254BigInt(ir.ExpectedEvaluation[:]),
+		Commitment4844:     *prover.BytesToBn254BigInt(versionedKzgHash[:]),
 		StartIndex:         params.StartIndex,
 		PreRoot:            params.PreRoot,
 		PostRoot:           params.PostRoot,

--- a/prover/insertion_proving_system.go
+++ b/prover/insertion_proving_system.go
@@ -85,7 +85,7 @@ func (ps *ProvingSystem) ProveInsertion(params *InsertionParameters) (*Insertion
 		idCommsTree.Update(i, params.IdComms[i])
 	}
 	incomingIdsTreeRoot := idCommsTree.Root()
-	incomingIdsTreeRoot = *bytesToBn254BigInt(incomingIdsTreeRoot.Bytes())
+	incomingIdsTreeRoot = *BytesToBn254BigInt(incomingIdsTreeRoot.Bytes())
 
 	proofs := make([][]frontend.Variable, ps.BatchSize)
 	for i := 0; i < int(ps.BatchSize); i++ {
@@ -106,9 +106,10 @@ func (ps *ProvingSystem) ProveInsertion(params *InsertionParameters) (*Insertion
 	if err != nil {
 		return nil, err
 	}
-	commitment4844 := *bytesToBn254BigInt(commitment[:])
+	versionedKzgHash := KzgToVersionedHash(commitment)
+	versionedKzgHashReduced := *BytesToBn254BigInt(versionedKzgHash[:])
 
-	challenge := bigIntsToChallenge([]big.Int{incomingIdsTreeRoot, commitment4844})
+	challenge := bigIntsToChallenge([]big.Int{incomingIdsTreeRoot, versionedKzgHashReduced})
 	kzgProof, evaluation, err := ctx.ComputeKZGProof(blob, challenge, numGoRoutines)
 	if err != nil {
 		return nil, err
@@ -121,8 +122,8 @@ func (ps *ProvingSystem) ProveInsertion(params *InsertionParameters) (*Insertion
 
 	assignment := InsertionMbuCircuit{
 		InputHash:          incomingIdsTreeRoot,
-		ExpectedEvaluation: evaluation[:],
-		Commitment4844:     commitment4844,
+		ExpectedEvaluation: *BytesToBn254BigInt(evaluation[:]),
+		Commitment4844:     versionedKzgHashReduced,
 		StartIndex:         params.StartIndex,
 		PreRoot:            params.PreRoot,
 		PostRoot:           params.PostRoot,


### PR DESCRIPTION
As per the EIP-4844 specs, KZG commitment should not be passed as raw
bytes. Instead, a versioned hash of the commitment should be used.
Implement the hashing function according to the specs and apply it on
the commitment. Use the hash instead of the raw commitment for
evaluation point calculation and pass the hash to the circuit instead.

Reduce the evaluation point value at the input to the circuiut as an
optimization, to avoid passing around large values.

Introduce relevant changes in the insertion circiut test as well as the
integration test and the prover itself. Export the BN254 reduction
function to the circuit utils file, as now it's used in the integration
test, which is outside of the prover package.