### PR TITLE
Remove lean from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,15 +22,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Install Elan
-      run: |
-        curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y -v --default-toolchain leanprover/lean4:nightly-2023-07-12
-        echo "LAKE_VERSION=$(~/.elan/bin/lake --version)" >> $GITHUB_ENV
-    - name: Cache dependencies
-      uses: actions/cache@v3
-      with:
-        path: formal-verification/lake-packages
-        key: "${{ env.LAKE_VERSION }}"
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
@@ -39,11 +30,4 @@ jobs:
       run: go build
     - name: Test
       run: go test
-    - name: Export circuit
-      run: ./gnark-mbu extract-circuit --output=formal-verification/FormalVerification.lean --tree-depth 30 --batch-size 4
-    - name: Build lean project
-      run: |
-        cd formal-verification
-        ulimit -s 65520
-        ~/.elan/bin/lake exe cache get
-        ~/.elan/bin/lake build || true
+


### PR DESCRIPTION
In 72c8ec7f lean was allowed to fail to unblock EIP-4844 work. Since then formal verification components never kept up, so remove them from CI altogether.